### PR TITLE
Fix 'Agent' is a type and must be imported using a type-only import...

### DIFF
--- a/packages/agents/browser.d.ts
+++ b/packages/agents/browser.d.ts
@@ -27,4 +27,5 @@ export interface Agent {
   synced(): Promise<void>;
 }
 
-export default Agent;
+const agent: Agent;
+export default agent;


### PR DESCRIPTION
…when 'verbatimModuleSyntax' is enabled.

I checked this change locally and it solves the compilation problem.