### PR TITLE
Fixed Typescript compilation and updated browser.d.ts

### DIFF
--- a/packages/agents/browser.d.ts
+++ b/packages/agents/browser.d.ts
@@ -17,15 +17,29 @@ export interface AgentEnvironment {
   context: string[];
 }
 
+export interface AgentUploadInfo {
+  name?: string,
+  type?: string,
+  data?: string | ArrayBuffer,
+  id: string,
+  browser?: boolean,
+  accept?: string,
+}
+
 export interface Agent {
+  login(provider: string): void;
+  logout(): void;
+  uuid(): string;
+  state(id: string, user?: string, domain?: string): Promise<object>;
+  metadata(id: string, user?: string, domain?: string): Promise<object>;
+  watch(id: string, callback: (update: { state: object }) => void, user?: string, domain?: string): void;
+  upload(info?: AgentUploadInfo): Promise<string>;
+  download(id?: string): Promise<Response>;
   environment(userId?: string): Promise<AgentEnvironment>;
-  state(ns?: string, user?: string, domain?: string): any;
-  upload(userId?: string): Promise<string>;
-  download(userId?: string): Promise<string>;
   close(): void;
   reset(ns: string): Promise<void>;
   synced(): Promise<void>;
 }
 
-const agent: Agent;
+declare const agent: Agent;
 export default agent;


### PR DESCRIPTION
Two changes:
- Added `declare` before `const agent: Agent` to fix a Typescript error.
- Updated `Agent` interface to match documentation.

@jasonford one question: methods `environment`, `close`, `reset` and `synced` are not documented, are they typed correctly?